### PR TITLE
Fix pagination visible page count

### DIFF
--- a/src/components/Pagination.test.ts
+++ b/src/components/Pagination.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { getVisiblePages } from '@/components/Pagination';
+
+describe('getVisiblePages', () => {
+  it('shows first pages when near start', () => {
+    expect(getVisiblePages(2, 10)).toEqual([1,2,3,4,5]);
+  });
+
+  it('shows last pages when near end', () => {
+    expect(getVisiblePages(9, 10)).toEqual([6,7,8,9,10]);
+  });
+
+  it('returns all pages when total pages less than max', () => {
+    expect(getVisiblePages(1, 3)).toEqual([1,2,3]);
+  });
+});

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -6,6 +6,32 @@ interface PaginationProps {
   basePath: string; // e.g., "/" or "/tag/react"
 }
 
+/**
+ * Calculate a list of visible page numbers for the pagination component.
+ * Ensures a consistent number of pages are shown even near the end of the list.
+ */
+export function getVisiblePages(
+  currentPage: number,
+  totalPages: number,
+  maxVisiblePages = 5
+): number[] {
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+  if (totalPages <= maxVisiblePages) {
+    return pages;
+  }
+
+  let start = Math.max(0, currentPage - Math.floor(maxVisiblePages / 2));
+  let end = start + maxVisiblePages;
+
+  if (end > totalPages) {
+    end = totalPages;
+    start = Math.max(0, end - maxVisiblePages);
+  }
+
+  return pages.slice(start, end);
+}
+
 export function Pagination({ currentPage, totalPages, basePath }: PaginationProps) {
   if (totalPages <= 1) {
     return null;
@@ -26,17 +52,7 @@ export function Pagination({ currentPage, totalPages, basePath }: PaginationProp
     return `${basePath}/page/${page}/`;
   };
 
-  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
-  
-  // Show max 5 pages around current page
-  const maxVisiblePages = 5;
-  let visiblePages = pages;
-  
-  if (totalPages > maxVisiblePages) {
-    const start = Math.max(0, currentPage - Math.floor(maxVisiblePages / 2));
-    const end = Math.min(totalPages, start + maxVisiblePages);
-    visiblePages = pages.slice(start, end);
-  }
+  const visiblePages = getVisiblePages(currentPage, totalPages);
 
   return (
     <nav className="flex justify-center items-center space-x-2 mt-12" aria-label="Pagination">

--- a/vitest.local.config.ts
+++ b/vitest.local.config.ts
@@ -1,0 +1,13 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- ensure pagination shows a consistent number of pages by adding `getVisiblePages`
- add unit tests for pagination display logic
- provide local vitest config for node-based tests

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npx vitest run` (fails: Playwright not installed)
- `npx vitest run src/components/Pagination.test.ts --config vitest.local.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_689e2437cc5c832aaa471475129630f9