### PR TITLE
Enable GitHub-flavored Markdown for MDX content

### DIFF
--- a/src/app/[year]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/[year]/[month]/[day]/[slug]/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
+import remarkGfm from 'remark-gfm';
 import TableOfContents from '@/components/TableOfContents';
 import { mdxComponents } from '@/mdx-components';
 
@@ -174,9 +175,12 @@ export default async function PostPage({ params }: PostPageProps) {
 
             {/* Post Content */}
             <div className="prose prose-lg dark:prose-invert max-w-none">
-              <MDXRemote 
-                source={post.content} 
+              <MDXRemote
+                source={post.content}
                 components={mdxComponents}
+                options={{
+                  mdxOptions: { remarkPlugins: [remarkGfm] },
+                }}
               />
             </div>
           </div>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
+import remarkGfm from 'remark-gfm';
 import { mdxComponents } from '@/mdx-components';
 import TableOfContents from '@/components/TableOfContents';
 
@@ -77,9 +78,12 @@ export default function AboutPage() {
 
           {/* Page Content */}
           <div className="prose prose-lg dark:prose-invert max-w-none">
-            <MDXRemote 
-              source={page.content} 
+            <MDXRemote
+              source={page.content}
               components={mdxComponents}
+              options={{
+                mdxOptions: { remarkPlugins: [remarkGfm] },
+              }}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- enable remark-gfm when rendering posts
- enable remark-gfm for static pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e24755d2c832a91949d69098b53a5