### PR TITLE
feat: sanitize mdx rendering

### DIFF
--- a/src/__tests__/mdx-sanitize.test.ts
+++ b/src/__tests__/mdx-sanitize.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import remarkRehype from 'remark-rehype';
+import rehypeSanitize from '@/lib/rehype-sanitize';
+import { sanitizeSchema } from '@/lib/sanitize-schema';
+import { visit } from 'unist-util-visit';
+import type { Element, Root } from 'hast';
+
+function processMDX(mdx: string) {
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkRehype)
+    .use(rehypeSanitize, sanitizeSchema);
+
+  return processor.runSync(processor.parse(mdx)) as Root;
+}
+
+describe('MDX sanitization', () => {
+  it('removes script elements', () => {
+    const tree = processMDX('Safe<script>alert(1)</script>');
+    let hasScript = false;
+    visit(tree, 'element', (node: Element) => {
+      if (node.tagName === 'script') hasScript = true;
+    });
+    expect(hasScript).toBe(false);
+  });
+
+  it('strips event handler attributes', () => {
+    const tree = processMDX('<img src="x" onerror="alert(1)" />');
+    let hasOnError = false;
+    visit(tree, 'element', (node: Element) => {
+      if (node.tagName === 'img' && 'onerror' in (node.properties || {})) {
+        hasOnError = true;
+      }
+    });
+    expect(hasOnError).toBe(false);
+  });
+});

--- a/src/app/(content)/[year]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/(content)/[year]/[month]/[day]/[slug]/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
-import remarkGfm from 'remark-gfm';
+import { mdxOptions } from '@/lib/mdx-options';
 import TableOfContents from '@/components/TableOfContents';
 import { mdxComponents } from '@/stories/mdx-components';
 
@@ -152,9 +152,7 @@ export default async function PostPage({ params }: PostPageProps) {
               <MDXRemote
                 source={post.content}
                 components={mdxComponents}
-                options={{
-                  mdxOptions: { remarkPlugins: [remarkGfm] },
-                }}
+                options={mdxOptions}
               />
             </div>
           </div>

--- a/src/app/(pages)/pages/[slug]/page.tsx
+++ b/src/app/(pages)/pages/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
-import remarkGfm from 'remark-gfm';
+import { mdxOptions } from '@/lib/mdx-options';
 import { mdxComponents } from '@/stories/mdx-components';
 import TableOfContents from '@/components/TableOfContents';
 
@@ -73,9 +73,7 @@ export default async function StaticPage({ params }: PageProps) {
             <MDXRemote
               source={page.content}
               components={mdxComponents}
-              options={{
-                mdxOptions: { remarkPlugins: [remarkGfm] },
-              }}
+              options={mdxOptions}
             />
           </div>
         </div>

--- a/src/lib/mdx-options.ts
+++ b/src/lib/mdx-options.ts
@@ -1,0 +1,10 @@
+import remarkGfm from 'remark-gfm';
+import rehypeSanitize from './rehype-sanitize';
+import { sanitizeSchema } from './sanitize-schema';
+
+export const mdxOptions = {
+  mdxOptions: {
+    remarkPlugins: [remarkGfm],
+    rehypePlugins: [[rehypeSanitize, sanitizeSchema]],
+  },
+};

--- a/src/lib/rehype-sanitize.ts
+++ b/src/lib/rehype-sanitize.ts
@@ -1,0 +1,39 @@
+import { visit } from 'unist-util-visit';
+import type { Root, Element } from 'hast';
+
+interface SanitizeSchema {
+  tagNames?: string[];
+  attributes?: Record<string, string[]>;
+}
+
+/**
+ * Minimal rehype plugin to sanitize HTML based on an allowlist schema.
+ * Removes disallowed elements and attributes, including all event handlers.
+ */
+export default function rehypeSanitize(schema: SanitizeSchema = {}) {
+  return function transformer(tree: Root) {
+    visit(tree, 'element', (node: Element, index, parent) => {
+      if (!parent || typeof index !== 'number') return;
+
+      // Remove disallowed tags
+      if (schema.tagNames && !schema.tagNames.includes(node.tagName)) {
+        parent.children.splice(index, 1);
+        return [visit.SKIP, index];
+      }
+
+      // Filter attributes based on allowlist and remove event handlers
+      const allowed = [
+        ...(schema.attributes?.[node.tagName] || []),
+        ...(schema.attributes?.['*'] || []),
+      ];
+
+      if (node.properties) {
+        for (const key of Object.keys(node.properties)) {
+          if (key.startsWith('on') || !allowed.includes(key)) {
+            delete (node.properties as Record<string, unknown>)[key];
+          }
+        }
+      }
+    });
+  };
+}

--- a/src/lib/sanitize-schema.ts
+++ b/src/lib/sanitize-schema.ts
@@ -1,0 +1,12 @@
+export const sanitizeSchema = {
+  tagNames: [
+    'a', 'b', 'blockquote', 'br', 'code', 'div', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'hr', 'img', 'li', 'ol', 'p', 'pre', 'span', 'strong', 'table', 'tbody', 'td', 'th',
+    'thead', 'tr', 'ul'
+  ],
+  attributes: {
+    a: ['href', 'title', 'rel', 'target'],
+    img: ['src', 'alt', 'title', 'width', 'height'],
+    '*': ['className']
+  }
+} as const;


### PR DESCRIPTION
## Summary
- add rehype-based HTML sanitizer with allowlist schema
- apply sanitizer to all MDX renders
- test that scripts and event handlers are removed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abb4dc76c8832a9339a61398cdcc4f