### PR TITLE
feat: add CSP nonce middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ All scripts use ESM loader pattern and are located in `scripts/` directory:
 - **Image optimization disabled**: Required for static export to GitHub Pages
 - **Search runs client-side**: No server dependency for search functionality
 
+## Content Security Policy
+
+The application emits a strict Content Security Policy (CSP) using Next.js middleware. A unique nonce is generated for every request and applied to inline `<script>` tags, allowing them to execute while blocking injected scripts. The middleware sets the `Content-Security-Policy` header with:
+
+- `script-src 'self' 'nonce-<random>' https://www.googletagmanager.com https://platform.twitter.com https://s.imgur.com`
+
+This restricts script execution to the site itself and the trusted domains above. Server components can read the nonce via `headers().get('x-nonce')` and pass it to `<script>` or `next/script` elements.
+
 ## Theme Toggle
 
 - Behavior: A toggle in the header switches between Light/Dark and persists in `localStorage` under key `theme` (`light` | `dark`).

--- a/src/app/(content)/[year]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/(content)/[year]/[month]/[day]/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { MDXRemote } from 'next-mdx-remote/rsc';
 import remarkGfm from 'remark-gfm';
 import TableOfContents from '@/components/TableOfContents';
 import { mdxComponents } from '@/stories/mdx-components';
+import { headers } from 'next/headers';
 
 interface PostPageProps {
   params: Promise<{
@@ -63,12 +64,14 @@ export default async function PostPage({ params }: PostPageProps) {
     notFound();
   }
 
+  const nonce = headers().get('x-nonce') ?? undefined;
   const structuredData = generateBlogPostStructuredData(post);
 
   return (
     <>
       {/* JSON-LD Structured Data */}
       <script
+        nonce={nonce}
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(structuredData),

--- a/src/app/(content)/page.tsx
+++ b/src/app/(content)/page.tsx
@@ -3,10 +3,12 @@ import { PostCard } from '@/components/PostCard';
 import { Pagination } from '@/components/Pagination';
 import { generateHomeMetadata, generateBlogStructuredData, generateWebsiteStructuredData } from '@/lib/seo';
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 
 export const metadata: Metadata = generateHomeMetadata();
 
 export default function Home() {
+  const nonce = headers().get('x-nonce') ?? undefined;
   try {
     const { posts, totalPages, currentPage } = getPaginatedPosts(1);
     
@@ -17,6 +19,7 @@ export default function Home() {
       <>
         {/* JSON-LD Structured Data */}
         <script
+          nonce={nonce}
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: JSON.stringify([blogStructuredData, websiteStructuredData]),

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { GoogleAnalytics } from "@/components/GoogleAnalytics";
 import { siteConfig } from "@/config/site";
+import { headers } from "next/headers";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -106,6 +107,7 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const nonce = headers().get('x-nonce') ?? undefined;
   // Build CSS variable overrides for light/dark from siteConfig.theme
   const light = siteConfig.theme?.light;
   const dark = siteConfig.theme?.dark;
@@ -121,6 +123,7 @@ export default function RootLayout({
       <head>
         {/* Pre-hydration theme script: apply user's theme choice before React mounts */}
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `(() => {
   try {
@@ -149,7 +152,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased font-sans`}
       >
-        <GoogleAnalytics />
+        <GoogleAnalytics nonce={nonce} />
         <div className="min-h-screen flex flex-col">
           <Header />
           <main className="flex-1">

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -3,16 +3,21 @@
 import Script from 'next/script';
 import { siteConfig } from '@/config/site';
 
-export function GoogleAnalytics() {
+interface GoogleAnalyticsProps {
+  nonce?: string;
+}
+
+export function GoogleAnalytics({ nonce }: GoogleAnalyticsProps) {
   const GA_TRACKING_ID = siteConfig.analytics.googleAnalyticsId;
-  
+
   return (
     <>
       <Script
+        nonce={nonce}
         src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
         strategy="afterInteractive"
       />
-      <Script id="google-analytics" strategy="afterInteractive">
+      <Script id="google-analytics" strategy="afterInteractive" nonce={nonce}>
         {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,44 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+function generateNonce(): string {
+  const array = new Uint8Array(16);
+  crypto.getRandomValues(array);
+  // Use Buffer when available (Node.js) otherwise fall back to btoa for Edge runtime
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(array).toString('base64');
+  }
+  let str = '';
+  for (const byte of array) {
+    str += String.fromCharCode(byte);
+  }
+  return btoa(str);
+}
+
+const TRUSTED_SCRIPT_SOURCES = [
+  "'self'",
+  'https://www.googletagmanager.com',
+  'https://platform.twitter.com',
+  'https://s.imgur.com',
+];
+
+export function middleware(req: NextRequest) {
+  const nonce = generateNonce();
+
+  const csp = [`script-src ${[...TRUSTED_SCRIPT_SOURCES, `'nonce-${nonce}'`].join(' ')}`].join('; ');
+
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set('x-nonce', nonce);
+
+  const res = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+
+  res.headers.set('Content-Security-Policy', csp);
+
+  return res;
+}
+
+export const config = {
+  matcher: '/:path*',
+};
+


### PR DESCRIPTION
## Summary
- secure script execution with CSP header and per-request nonce
- propagate nonce to theme and analytics scripts
- document new content security policy

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abb4f25834832a99f0dc54a15a6114