### PR TITLE
Use next/image for MDX content

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ draft: false
 showToc: false
 ```
 
+For static images rendered in MDX, Next.js's `<Image>` component requires explicit dimensions. Add `imageWidth` and `imageHeight` fields to your frontmatter and use them when referencing the image:
+
+```yaml
+imageWidth: 800
+imageHeight: 600
+```
+
+```mdx
+<img src="/images/example.png" alt="Example" width={frontmatter.imageWidth} height={frontmatter.imageHeight} />
+```
+
 ### Content Processing
 - **Reading time calculation** automatically added to all posts
 - **Heading extraction** for table of contents generation
@@ -109,9 +120,9 @@ All scripts use ESM loader pattern and are located in `scripts/` directory:
 ## Important Implementation Notes
 
 - **Content outside src/**: MDX files in `content/` directory separate from Next.js source
-- **Trailing slashes required**: All routes end with `/` for GitHub Pages compatibility  
+- **Trailing slashes required**: All routes end with `/` for GitHub Pages compatibility
 - **Static-only**: No server-side rendering or API routes in production
-- **Image optimization disabled**: Required for static export to GitHub Pages
+- **Image optimization enabled**: Uses Next.js `<Image>` with static export; images require width and height in frontmatter
 - **Search runs client-side**: No server dependency for search functionality
 
 ## Theme Toggle

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,15 +10,11 @@ const nextConfig: NextConfig = {
     cpus: 1,
   },
   images: {
-    unoptimized: true,
+    unoptimized: false,
     remotePatterns: [
       {
         protocol: 'https',
         hostname: 'i.redd.it',
-      },
-      {
-        protocol: 'https',
-        hostname: '**',
       },
     ],
   },

--- a/src/stories/mdx-components.tsx
+++ b/src/stories/mdx-components.tsx
@@ -1,9 +1,36 @@
 import type { MDXComponents } from 'mdx/types';
+import Image, { ImageProps } from 'next/image';
 import SmartLink from '@/components/SmartLink';
 import HeadingAnchor from '@/components/HeadingAnchor';
 import YouTubeEmbed from '@/components/YouTubeEmbed';
 import MediaEmbed from '@/components/MediaEmbed';
 import { generateHeadingId } from '@/lib/utils';
+
+type MDXImageProps = Omit<ImageProps, 'src' | 'alt'> & {
+  src: string;
+  alt?: string;
+};
+
+function MDXImage({
+  src,
+  alt = '',
+  width,
+  height,
+  className,
+  ...props
+}: MDXImageProps) {
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      width={typeof width === 'string' ? parseInt(width, 10) : width}
+      height={typeof height === 'string' ? parseInt(height, 10) : height}
+      className={`mx-auto my-6 rounded-lg shadow-md ${className ?? ''}`}
+      style={{ width: '100%', height: 'auto' }}
+      {...props}
+    />
+  );
+}
 
 /**
  * Comprehensive MDX component overrides for consistent rendering
@@ -221,18 +248,8 @@ export const mdxComponents: MDXComponents = {
     </em>
   ),
 
-  // Images with centering and responsive styling
-  // Render a plain <img> so it is valid inside paragraphs (MDX often nests images in <p>)
-  // Using img instead of next/image for static export compatibility
-  img: ({ src, alt, ...props }) => (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img
-      src={src}
-      alt={alt}
-      className="mx-auto my-6 max-w-full h-auto rounded-lg shadow-md"
-      {...props}
-    />
-  ),
+  // Images wrapped with next/image for optimization
+  img: (props) => <MDXImage {...props} />,
 
   // Custom components
   YouTubeEmbed,


### PR DESCRIPTION
## Summary
- wrap MDX `img` elements with a responsive `next/image` component
- enable Next.js image optimization and restrict remote patterns
- document width/height frontmatter requirement for static MDX images

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abb5a30830832aa859fcbb8d0c7be1