### PR TITLE
chore: secure workflow and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,19 +19,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65a472b7d6dd3c7be3fac65d2eddbd6a08 # v4
         
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@8f66a113f04f52f6e1d788c8b4aeee855fd47571 # v4
         with:
           node-version: "20"
           cache: npm
           
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@6e0d80bcc8cd7ea4c3c07c36ce3741659c4a6b40 # v4
         
       - name: Install dependencies
         run: npm ci
+
+      - name: Audit dependencies
+        run: npm audit --production
+        continue-on-error: true
         
       - name: Run tests
         run: npm run test
@@ -46,7 +50,7 @@ jobs:
         run: npm run build
         
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@c6bc1088c58945d4da751451bfbe4801bb74b932 # v3
         with:
           path: ./out
 
@@ -59,4 +63,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@49815636d341a5785cc1caa57bd9b464ee5acba1 # v4


### PR DESCRIPTION
## Summary
- pin GitHub Actions in deploy workflow to specific commits
- run `npm audit --production` during deployments without failing workflow
- configure Dependabot to track npm and GitHub Actions updates

## Testing
- `npm test`
- `npm audit --production` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68abb5abfc64832a8b7cbec2c9e39a51