### PR TITLE
Fix static export build errors

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,7 +10,8 @@ const nextConfig: NextConfig = {
     cpus: 1,
   },
   images: {
-    unoptimized: false,
+    // Disable the Image Optimization API for static exports
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',

--- a/src/app/(content)/[year]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/(content)/[year]/[month]/[day]/[slug]/page.tsx
@@ -9,7 +9,6 @@ import { MDXRemote } from 'next-mdx-remote/rsc';
 import { mdxOptions } from '@/lib/mdx-options';
 import TableOfContents from '@/components/TableOfContents';
 import { mdxComponents } from '@/stories/mdx-components';
-import { headers } from 'next/headers';
 
 interface PostPageProps {
   params: Promise<{
@@ -64,14 +63,12 @@ export default async function PostPage({ params }: PostPageProps) {
     notFound();
   }
 
-  const nonce = (await headers()).get('x-nonce') ?? undefined;
   const structuredData = generateBlogPostStructuredData(post);
 
   return (
     <>
       {/* JSON-LD Structured Data */}
       <script
-        nonce={nonce}
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(structuredData),

--- a/src/app/(content)/page.tsx
+++ b/src/app/(content)/page.tsx
@@ -3,12 +3,10 @@ import { PostCard } from '@/components/PostCard';
 import { Pagination } from '@/components/Pagination';
 import { generateHomeMetadata, generateBlogStructuredData, generateWebsiteStructuredData } from '@/lib/seo';
 import type { Metadata } from 'next';
-import { headers } from 'next/headers';
 
 export const metadata: Metadata = generateHomeMetadata();
 
 export default function Home() {
-  const nonce = headers().get('x-nonce') ?? undefined;
   try {
     const { posts, totalPages, currentPage } = getPaginatedPosts(1);
     
@@ -19,7 +17,6 @@ export default function Home() {
       <>
         {/* JSON-LD Structured Data */}
         <script
-          nonce={nonce}
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: JSON.stringify([blogStructuredData, websiteStructuredData]),


### PR DESCRIPTION
## Summary
- Remove `headers()` usage so home and post pages can be statically exported
- Disable Next.js image optimization for static export
- Revert generated RSS and sitemap files

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch `Geist` and `Geist Mono` fonts; please ensure network access to Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68abca5f433c832a90c51f744d68c7cc